### PR TITLE
Fix delete crash when animal has associated tests

### DIFF
--- a/app/controllers/animals_controller.rb
+++ b/app/controllers/animals_controller.rb
@@ -51,6 +51,6 @@ class AnimalsController < ApplicationController
   end
 
   def invalid_foreign_key
-    redirect_to animals_path, notice: 'Animal can not be destroyed.'
+    redirect_to animals_path, notice: 'Animal cannot be deleted while it has associated tests.'
   end
 end

--- a/app/models/animal.rb
+++ b/app/models/animal.rb
@@ -1,3 +1,3 @@
 class Animal < ApplicationRecord
-  has_many :tests, dependent: :restrict_with_exception
+  has_many :tests
 end

--- a/app/views/animals/show.html.haml
+++ b/app/views/animals/show.html.haml
@@ -18,5 +18,6 @@
     %td Actions
     %td
       = link_to 'Edit', edit_animal_path(@animal)
+      = button_to 'Destroy', animal_path(@animal), method: :delete, data: { turbo_confirm: 'Are you sure?' }
       = link_to 'Back', animals_path
 

--- a/test/controllers/animals_controller_test.rb
+++ b/test/controllers/animals_controller_test.rb
@@ -42,6 +42,14 @@ class AnimalsControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to animal_url(@animal)
   end
 
+  test 'should not destroy animal with associated tests' do
+    assert_no_difference('Animal.count') do
+      delete animal_url(@animal)
+    end
+
+    assert_redirected_to animals_url
+  end
+
   test 'should destroy animal' do
     assert_difference('Animal.count', -1) do
       delete animal_url(animals(:two))

--- a/test/fixtures/animals.yml
+++ b/test/fixtures/animals.yml
@@ -13,3 +13,8 @@ two:
   unique_tag: "3241-2434"
   species: "Domestic Cattle"
   breed: "Red angus"
+
+with_tests:
+  unique_tag: "WTS-001"
+  species: "Domestic Cattle"
+  breed: "Hereford"

--- a/test/fixtures/tests.yml
+++ b/test/fixtures/tests.yml
@@ -9,3 +9,9 @@ one:
   veterinarian: one
   name: "Bovine Enteric Disease Panel"
   result: "Negative"
+
+two:
+  animal: with_tests
+  veterinarian: one
+  name: "Tuberculin Skin Test"
+  result: "Positive"

--- a/test/system/animals_test.rb
+++ b/test/system/animals_test.rb
@@ -1,10 +1,6 @@
 require "application_system_test_case"
 
 class AnimalsTest < ApplicationSystemTestCase
-  setup do
-    @animal = animals(:one)
-  end
-
   test "visiting the index" do
     visit animals_url
     assert_selector "h1", text: "Animals"
@@ -37,5 +33,25 @@ class AnimalsTest < ApplicationSystemTestCase
     end
 
     assert_text "Animal was successfully destroyed"
+  end
+
+  test "destroying an animal with associated tests from index shows error message" do
+    visit animals_url
+
+    row = find("tr", text: animals(:with_tests).unique_tag)
+    accept_confirm do
+      row.click_on "Destroy"
+    end
+
+    assert_text "Animal cannot be deleted while it has associated tests"
+  end
+
+  test "destroying an animal with associated tests from show page shows error message" do
+    visit animal_url(animals(:with_tests))
+    accept_confirm do
+      click_on "Destroy"
+    end
+
+    assert_text "Animal cannot be deleted while it has associated tests"
   end
 end


### PR DESCRIPTION
Closes #4

| 👀 𝘈𝘉𝘖𝘜𝘛 |
|---------------|

Fixes the crash when deleting an animal that has associated test records. The model used `restrict_with_exception` which raises `DeleteRestrictionError`, but the controller only rescues `InvalidForeignKey` - this switches to relying on the database foreign key constraint so the existing rescue works correctly.

| 🎉 𝘞𝘏𝘈𝘛 𝘊𝘏𝘈𝘕𝘎𝘌𝘋 |
|----------------------------|

- Removed `dependent: :restrict_with_exception` from `Animal#tests` so deletion is blocked by the DB foreign key constraint (raises `InvalidForeignKey` which the controller already rescues)
- Improved error message: "Animal cannot be deleted while it has associated tests."
- Added Destroy button to animal #show page
- Added controller test verifying animals with tests cannot be deleted
- Added system tests for the error message on both index and show pages

| 📄️ 𝘋𝘖𝘊𝘜𝘔𝘌𝘕𝘛𝘈𝘛𝘐𝘖𝘕 𝘓𝘐𝘕𝘒𝘚 |
|-------------------------------------------|

- Requirements ⇢ https://github.com/jkidd86/jkidd86-tracefirst-interview-code-test-bgreeff/issues/4


| ✅ 𝘊𝘏𝘌𝘊𝘒𝘓𝘐𝘚𝘛 |
|----------------------|

- [x] I have performed a self-review of my code and tested my change locally
- [x] I have added tests that prove my fix is effective or that my feature works