### PR TITLE
Fix N+1 queries in tests#index

### DIFF
--- a/app/controllers/tests_controller.rb
+++ b/app/controllers/tests_controller.rb
@@ -4,7 +4,7 @@ class TestsController < ApplicationController
   rescue_from ActiveRecord::InvalidForeignKey, with: :invalid_foreign_key
 
   def index
-    @tests = Test.all
+    @tests = Test.preload(:animal, :veterinarian)
 
     @tests = @tests.where(result: params[:result]) if params[:result].present?
   end

--- a/app/views/tests/_test.html.haml
+++ b/app/views/tests/_test.html.haml
@@ -1,0 +1,9 @@
+%tr
+  %td= test.name
+  %td= test.result
+  %td= test.animal&.unique_tag
+  %td= test.veterinarian&.name
+  %td
+    = button_to 'Show', test_path(test), method: :get
+    = button_to 'Edit', edit_test_path(test), method: :get
+    = button_to 'Destroy', test_path(test), method: :delete, data: { turbo_confirm: 'Are you sure?' }

--- a/app/views/tests/index.html.haml
+++ b/app/views/tests/index.html.haml
@@ -11,16 +11,7 @@
       %th Animal
       %th Veterinarian
   %tbody
-    - @tests.each do |test|
-      %tr
-        %td= test.name
-        %td= test.result
-        %td= test.animal&.unique_tag
-        %td= test.veterinarian&.name
-        %td
-          = button_to 'Show', test_path(test), method: :get
-          = button_to 'Edit', edit_test_path(test), method: :get
-          = button_to 'Destroy', test_path(test), method: :delete, data: { turbo_confirm: 'Are you sure?' }
+    = render @tests
 %br
 = link_to 'New Test', new_test_path
 


### PR DESCRIPTION
Closes #5

| 👀 𝘈𝘉𝘖𝘜𝘛 |
|---------------|

Fixes N+1 query problem in `tests#index` by eager loading the `animal` and `veterinarian` associations. With 400 seeded tests, - reduces database queries from ~801 to 3.

Each iteration - for rendering each test - needs to execute two more queries to load the animal and vet information for each test.

| 🎉 𝘞𝘏𝘈𝘛 𝘊𝘏𝘈𝘕𝘎𝘌𝘋 |
|----------------------------|

- Replace `Test.all` with `Test.preload(:animal, :veterinarian)` in `TestsController#index`

| 📄️ 𝘋𝘖𝘊𝘜𝘔𝘌𝘕𝘛𝘈𝘛𝘐𝘖𝘕 𝘓𝘐𝘕𝘒𝘚 |
|-------------------------------------------|

- Requirements ⇢ https://github.com/jkidd86/jkidd86-tracefirst-interview-code-test-bgreeff/issues/5

| ✏️ 𝘕𝘖𝘛𝘌 |
|-------------|

Used `preload` instead of `includes` since we dont want a join.

| ✅ 𝘊𝘏𝘌𝘊𝘒𝘓𝘐𝘚𝘛 |
|----------------------|

- [x] I have performed a self-review of my code and tested my change locally
