### PR TITLE
Fix vet controller admin escalation vulnerability

### DIFF
--- a/app/controllers/veterinarians_controller.rb
+++ b/app/controllers/veterinarians_controller.rb
@@ -55,7 +55,7 @@ class VeterinariansController < ApplicationController
   end
 
   def veterinarian_params
-    params.require(:veterinarian).permit!
+    params.require(:veterinarian).permit(:name, :status, :number)
   end
 
   def invalid_foreign_key

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -1,11 +1,7 @@
 {
   "ignored_warnings": [
-    {
+{
       "fingerprint": "40be17ee84017c91503dab23873e24bdd71665ab665bf6f351cfc09ff83e6582",
-      "note": "Issue #3 - permit! will be replaced with explicit params"
-    },
-    {
-      "fingerprint": "554f2244df80d7764a8b4016704b164715c2650c4854888e7d3a20dd789437e5",
       "note": "Ruby 3.2 EOL - upgrade to 3.3 planned"
     }
   ]

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -1,6 +1,6 @@
 {
   "ignored_warnings": [
-{
+    {
       "fingerprint": "40be17ee84017c91503dab23873e24bdd71665ab665bf6f351cfc09ff83e6582",
       "note": "Ruby 3.2 EOL - upgrade to 3.3 planned"
     }

--- a/test/controllers/veterinarians_controller_test.rb
+++ b/test/controllers/veterinarians_controller_test.rb
@@ -49,7 +49,8 @@ class VeterinariansControllerTest < ActionDispatch::IntegrationTest
                                                       status: 'available',
                                                       number: '+12125551234',
                                                       admin: true } }
-    assert_not Veterinarian.last.admin
+    vet = Veterinarian.find(response.location.match(/veterinarians\/(\d+)/)[1])
+    assert_not vet.admin
   end
 
   test 'should not allow admin escalation on update' do

--- a/test/controllers/veterinarians_controller_test.rb
+++ b/test/controllers/veterinarians_controller_test.rb
@@ -44,6 +44,20 @@ class VeterinariansControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to veterinarian_url(@veterinarian)
   end
 
+  test 'should not allow admin escalation on create' do
+    post veterinarians_url, params: { veterinarian: { name: 'Mallory',
+                                                      status: 'available',
+                                                      number: '+12125551234',
+                                                      admin: true } }
+    assert_not Veterinarian.last.admin
+  end
+
+  test 'should not allow admin escalation on update' do
+    refute @veterinarian.admin
+    patch veterinarian_url(@veterinarian), params: { veterinarian: { admin: true } }
+    refute @veterinarian.reload.admin
+  end
+
   test 'should destroy veterinarian' do
     assert_difference('Veterinarian.count', -1) do
       delete veterinarian_url(veterinarians(:two))


### PR DESCRIPTION
Closes #3

| 👀 𝘈𝘉𝘖𝘜𝘛 |
|---------------|

Fixes a permission escalation vulnerability where `permit!` in the veterinarians controller allowed any parameter (including `admin`) to be mass-assigned.

User can just del `disabled` using chrome: right-click -> inspect.

| 🎉 𝘞𝘏𝘈𝘛 𝘊𝘏𝘈𝘕𝘎𝘌𝘋 |
|----------------------------|

- Replaced `params.require(:veterinarian).permit!` with an explicit allowlist: `.permit(:name, :status, :number)`
- Added controller tests verifying that `admin: true` is rejected on both create and update

| 📄️ 𝘋𝘖𝘊𝘜𝘔𝘌𝘕𝘛𝘈𝘛𝘐𝘖𝘕 𝘓𝘐𝘕𝘒𝘚 |
|-------------------------------------------|

- Requirements ⇢ https://github.com/jkidd86/jkidd86-tracefirst-interview-code-test-bgreeff/issues/3

| ✅ 𝘊𝘏𝘌𝘊𝘒𝘓𝘐𝘚𝘛 |
|----------------------|

- [x] I have added tests that prove my fix is effective or that my feature works