### PR TITLE
Soft delete animals and veterinarians

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,6 +31,8 @@ gem 'haml-rails', '~> 2.1'
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.16', require: false
 
+gem "discard", "~> 1.4"
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[mri windows], require: "debug/prelude"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -109,6 +109,8 @@ GEM
     debug (1.11.1)
       irb (~> 1.10)
       reline (>= 0.3.8)
+    discard (1.4.0)
+      activerecord (>= 4.2, < 9.0)
     docile (1.4.1)
     drb (2.2.3)
     erb (6.0.2)
@@ -395,6 +397,7 @@ DEPENDENCIES
   capybara (>= 3.39)
   dartsass-rails (~> 0.5)
   debug
+  discard (~> 1.4)
   guard
   guard-minitest
   haml-rails (~> 2.1)

--- a/app/controllers/animals_controller.rb
+++ b/app/controllers/animals_controller.rb
@@ -33,7 +33,7 @@ class AnimalsController < ApplicationController
   end
 
   def destroy
-    if @animal.destroy
+    if @animal.discard
       redirect_to animals_path, notice: 'Animal was successfully destroyed'
     else
       redirect_to animals_path, error: 'Animal could not be destroyed'

--- a/app/controllers/veterinarians_controller.rb
+++ b/app/controllers/veterinarians_controller.rb
@@ -41,7 +41,7 @@ class VeterinariansController < ApplicationController
   end
 
   def destroy
-    @veterinarian.destroy
+    @veterinarian.discard
     respond_to do |format|
       format.html { redirect_to veterinarians_url, notice: 'Veterinarian was successfully destroyed.' }
       format.json { head :no_content }
@@ -59,6 +59,6 @@ class VeterinariansController < ApplicationController
   end
 
   def invalid_foreign_key
-    redirect_to veterinarians_path, notice: 'Veterinarian can not be destroyed.'
+    redirect_to veterinarians_path, notice: 'Veterinarian cannot be deleted while it has associated tests.'
   end
 end

--- a/app/models/animal.rb
+++ b/app/models/animal.rb
@@ -1,3 +1,5 @@
 class Animal < ApplicationRecord
   has_many :tests
+
+  soft_deletable dont_orphan: :tests
 end

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,3 +1,8 @@
 class ApplicationRecord < ActiveRecord::Base
   self.abstract_class = true
+
+  def self.soft_deletable(dont_orphan: [])
+    include SoftDeletable
+    dont_orphan(*Array(dont_orphan))
+  end
 end

--- a/app/models/concerns/soft_deletable.rb
+++ b/app/models/concerns/soft_deletable.rb
@@ -11,7 +11,7 @@ module SoftDeletable
     def dont_orphan(*associations)
       before_discard do
         associations.each do |assoc|
-          raise ActiveRecord::InvalidForeignKey, "Cannot discard #{model_name.human.downcase} with associated #{assoc}" if send(assoc).any?
+          raise ActiveRecord::InvalidForeignKey, "Cannot discard #{model_name.human.downcase} with associated #{assoc}" if send(assoc).exists?
         end
       end
     end

--- a/app/models/concerns/soft_deletable.rb
+++ b/app/models/concerns/soft_deletable.rb
@@ -1,0 +1,19 @@
+module SoftDeletable
+  extend ActiveSupport::Concern
+
+  included do
+    include Discard::Model
+    default_scope -> { kept }
+    scope :all_discarded, -> { with_discarded.discarded }
+  end
+
+  class_methods do
+    def dont_orphan(*associations)
+      before_discard do
+        associations.each do |assoc|
+          raise ActiveRecord::InvalidForeignKey, "Cannot discard #{model_name.human.downcase} with associated #{assoc}" if send(assoc).any?
+        end
+      end
+    end
+  end
+end

--- a/app/models/veterinarian.rb
+++ b/app/models/veterinarian.rb
@@ -1,3 +1,5 @@
 class Veterinarian < ApplicationRecord
   has_many :tests, dependent: :restrict_with_exception
+
+  soft_deletable dont_orphan: :tests
 end

--- a/app/views/veterinarians/show.html.haml
+++ b/app/views/veterinarians/show.html.haml
@@ -21,5 +21,6 @@
     %td Actions
     %td
       = link_to 'Edit', edit_veterinarian_path(@veterinarian)
+      = button_to 'Destroy', veterinarian_path(@veterinarian), method: :delete, data: { turbo_confirm: 'Are you sure?' }
       = link_to 'Back', veterinarians_path
 

--- a/db/migrate/20260305163841_add_discarded_at_to_animals.rb
+++ b/db/migrate/20260305163841_add_discarded_at_to_animals.rb
@@ -1,0 +1,6 @@
+class AddDiscardedAtToAnimals < ActiveRecord::Migration[8.1]
+  def change
+    add_column :animals, :discarded_at, :datetime
+    add_index :animals, :discarded_at
+  end
+end

--- a/db/migrate/20260305201607_add_discarded_at_to_veterinarians.rb
+++ b/db/migrate/20260305201607_add_discarded_at_to_veterinarians.rb
@@ -1,0 +1,6 @@
+class AddDiscardedAtToVeterinarians < ActiveRecord::Migration[8.1]
+  def change
+    add_column :veterinarians, :discarded_at, :datetime
+    add_index :veterinarians, :discarded_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,36 +10,39 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_11_21_141910) do
-
+ActiveRecord::Schema[8.1].define(version: 2026_03_05_201607) do
   create_table "animals", force: :cascade do |t|
-    t.string "unique_tag"
+    t.date "birth_date"
+    t.string "breed"
+    t.datetime "created_at", null: false
+    t.datetime "discarded_at"
     t.string "name"
     t.string "species"
-    t.string "breed"
-    t.date "birth_date"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.string "unique_tag"
+    t.datetime "updated_at", null: false
+    t.index ["discarded_at"], name: "index_animals_on_discarded_at"
   end
 
   create_table "tests", force: :cascade do |t|
+    t.integer "animal_id"
+    t.datetime "created_at", null: false
     t.string "name"
     t.string "result"
-    t.integer "animal_id"
+    t.datetime "updated_at", null: false
     t.integer "veterinarian_id"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
     t.index ["animal_id"], name: "index_tests_on_animal_id"
     t.index ["veterinarian_id"], name: "index_tests_on_veterinarian_id"
   end
 
   create_table "veterinarians", force: :cascade do |t|
-    t.string "name"
-    t.string "status"
     t.boolean "admin", default: false
+    t.datetime "created_at", null: false
+    t.datetime "discarded_at"
+    t.string "name"
     t.string "number"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.string "status"
+    t.datetime "updated_at", null: false
+    t.index ["discarded_at"], name: "index_veterinarians_on_discarded_at"
   end
 
   add_foreign_key "tests", "animals"

--- a/test/controllers/animals_controller_test.rb
+++ b/test/controllers/animals_controller_test.rb
@@ -50,11 +50,18 @@ class AnimalsControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to animals_url
   end
 
-  test 'should destroy animal' do
-    assert_difference('Animal.count', -1) do
-      delete animal_url(animals(:two))
+  test 'should soft delete animal' do
+    animal = animals(:two)
+
+    assert_no_difference('Animal.unscoped.count') do
+      delete animal_url(animal)
     end
 
+    animal.reload
+    assert animal.discarded?
+    assert_not_nil animal.discarded_at
+    assert_not_includes Animal.all, animal
+    assert_includes Animal.all_discarded, animal
     assert_redirected_to animals_url
   end
 end

--- a/test/controllers/veterinarians_controller_test.rb
+++ b/test/controllers/veterinarians_controller_test.rb
@@ -44,11 +44,26 @@ class VeterinariansControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to veterinarian_url(@veterinarian)
   end
 
-  test 'should destroy veterinarian' do
-    assert_difference('Veterinarian.count', -1) do
-      delete veterinarian_url(veterinarians(:two))
+  test 'should not destroy veterinarian with associated tests' do
+    assert_no_difference('Veterinarian.count') do
+      delete veterinarian_url(veterinarians(:with_tests))
     end
 
+    assert_redirected_to veterinarians_url
+  end
+
+  test 'should soft delete veterinarian' do
+    vet = veterinarians(:two)
+
+    assert_no_difference('Veterinarian.unscoped.count') do
+      delete veterinarian_url(vet)
+    end
+
+    vet.reload
+    assert vet.discarded?
+    assert_not_nil vet.discarded_at
+    assert_not_includes Veterinarian.all, vet
+    assert_includes Veterinarian.all_discarded, vet
     assert_redirected_to veterinarians_url
   end
 end

--- a/test/fixtures/tests.yml
+++ b/test/fixtures/tests.yml
@@ -12,6 +12,6 @@ one:
 
 two:
   animal: with_tests
-  veterinarian: one
+  veterinarian: with_tests
   name: "Tuberculin Skin Test"
   result: "Positive"

--- a/test/fixtures/veterinarians.yml
+++ b/test/fixtures/veterinarians.yml
@@ -15,3 +15,9 @@ two:
   status: "offline"
   admin: true
   number: "+24986502759"
+
+with_tests:
+  name: "Dr. Tests"
+  status: "available"
+  admin: false
+  number: "+18005551234"

--- a/test/models/concerns/soft_deletable/with_protected_associations_test.rb
+++ b/test/models/concerns/soft_deletable/with_protected_associations_test.rb
@@ -1,0 +1,46 @@
+require "test_helper"
+
+class ProtectedAssoc < ApplicationRecord
+  self.table_name = "animals"
+  has_many :tests, foreign_key: "animal_id"
+  soft_deletable dont_orphan: :tests
+end
+
+class SoftDeletableWithProtectedAssociationsTest < ActiveSupport::TestCase
+  test "discarding a record without associated records succeeds" do
+    record = ProtectedAssoc.find(animals(:two).id)
+    assert record.discard
+    assert record.discarded?
+  end
+
+  test "discarding a record with protected association raises InvalidForeignKey" do
+    record = ProtectedAssoc.find(animals(:with_tests).id)
+    error = assert_raises(ActiveRecord::InvalidForeignKey) do
+      record.discard
+    end
+    assert_match "Cannot discard protected assoc with associated tests", error.message
+    assert record.kept?
+  end
+
+  test ".all|.kept scope excludes discarded records" do
+    record = ProtectedAssoc.find(animals(:two).id)
+    record.discard
+    assert_not_includes ProtectedAssoc.all, record
+    assert_not_includes ProtectedAssoc.kept, record
+  end
+
+  test "all_discarded scope returns only discarded records" do
+    not_deleted = ProtectedAssoc.find(animals(:one).id)
+    record = ProtectedAssoc.find(animals(:two).id)
+    record.discard
+    assert_includes ProtectedAssoc.all_discarded, record
+    assert_not_includes ProtectedAssoc.all_discarded, not_deleted
+  end
+
+  test "unscoped count does not change after discard" do
+    record = ProtectedAssoc.find(animals(:two).id)
+    assert_no_difference("ProtectedAssoc.unscoped.count") do
+      record.discard
+    end
+  end
+end

--- a/test/models/concerns/soft_deletable/without_protected_associations_test.rb
+++ b/test/models/concerns/soft_deletable/without_protected_associations_test.rb
@@ -1,0 +1,36 @@
+require "test_helper"
+
+class UnprotectedAssoc < ApplicationRecord
+  self.table_name = "animals"
+  has_many :tests, foreign_key: "animal_id"
+  soft_deletable
+end
+
+class SoftDeletableWithoutProtectedAssociationsTest < ActiveSupport::TestCase
+  test "discarding a record without associated records succeeds" do
+    record = UnprotectedAssoc.find(animals(:two).id)
+    assert record.discard
+    assert record.discarded?
+  end
+
+  test "discarding a record with associated records succeeds" do
+    record = UnprotectedAssoc.find(animals(:with_tests).id)
+    assert record.discard
+    assert record.discarded?
+  end
+
+  test "kept scope excludes discarded records" do
+    record = UnprotectedAssoc.find(animals(:two).id)
+    record.discard
+    assert_not_includes UnprotectedAssoc.all, record
+    assert_not_includes UnprotectedAssoc.kept, record
+  end
+
+  test "all_discarded scope returns only discarded records" do
+    not_deleted = UnprotectedAssoc.find(animals(:one).id)
+    record = UnprotectedAssoc.find(animals(:two).id)
+    record.discard
+    assert_includes UnprotectedAssoc.all_discarded, record
+    assert_not_includes UnprotectedAssoc.all_discarded, not_deleted
+  end
+end

--- a/test/system/veterinarians_test.rb
+++ b/test/system/veterinarians_test.rb
@@ -38,4 +38,24 @@ class VeterinariansTest < ApplicationSystemTestCase
 
     assert_text "Veterinarian was successfully destroyed"
   end
+
+  test "destroying a veterinarian with associated tests from index shows error message" do
+    visit veterinarians_url
+
+    row = find("tr", text: veterinarians(:with_tests).name)
+    accept_confirm do
+      row.click_on "Destroy"
+    end
+
+    assert_text "Veterinarian cannot be deleted while it has associated tests"
+  end
+
+  test "destroying a veterinarian with associated tests from show page shows error message" do
+    visit veterinarian_url(veterinarians(:with_tests))
+    accept_confirm do
+      click_on "Destroy"
+    end
+
+    assert_text "Veterinarian cannot be deleted while it has associated tests"
+  end
 end


### PR DESCRIPTION
```
main
  └─ issue/4/fix-delete-restriction-error (PR #10)
      └─ issue/1/soft-delete ← current
```

Closes #1
Closes #4

| 👀 𝘈𝘉𝘖𝘜𝘛 |
|---------------|

Replaces hard deletion of animals and veterinarians with soft delete using the `discard` gem. Animals & Vets with associated test records are blocked from deletion with error message to user.

| 🎉 𝘞𝘏𝘈𝘛 𝘊𝘏𝘈𝘕𝘎𝘌𝘋 |
|----------------------------|

- Added `discard` gem and created `SoftDeletable` concern with `dont_orphan` option that raises `InvalidForeignKey` when discarding records with protected associations
- Applied `soft_deletable dont_orphan: :tests` to `Animal` and `Veterinarian` models
- Changed controllers to call `discard` instead of `destroy`
- Added `discarded_at` column + index to `animals` and `veterinarians` tables

| 📄️ 𝘋𝘖𝘊𝘜𝘔𝘌𝘕𝘛𝘈𝘛𝘐𝘖𝘕 𝘓𝘐𝘕𝘒𝘚 |
|-------------------------------------------|

- Requirements ⇢ https://github.com/jkidd86/jkidd86-tracefirst-interview-code-test-bgreeff/issues/1
- Requirements ⇢ https://github.com/jkidd86/jkidd86-tracefirst-interview-code-test-bgreeff/issues/4

| ✏️ 𝘕𝘖𝘛𝘌 |
|-------------|

The `SoftDeletable` concern uses a `default_scope` to automatically exclude discarded records from all queries. Use `.all_discarded` to access soft-deleted records.

Race condition is possible (TOCTOU).
If we are worried about this - recommend switching to Postgres and using SERIALIZABLE isolation.

`transaction(isolation: :serializable)`

We can also lock the tests table, but that could cause a perf issue.

| ✅ 𝘊𝘏𝘌𝘊𝘒𝘓𝘐𝘚𝘛 |
|----------------------|

- [x] I have performed a self-review of my code and tested my change locally
- [x] I have added tests that prove my fix is effective or that my feature works